### PR TITLE
Annotation rule about recursive/overloaded methods

### DIFF
--- a/sections/type_annotation.adoc
+++ b/sections/type_annotation.adoc
@@ -21,6 +21,7 @@ In case of doubt you can refer to the below hint-questions to wether or not, inc
 
 * Is it a parameter? **Yes**, you have to.
 * Is it a public methods return value? **Yes**, for self-documenting code and control over exported types.
+* Is it a recursive or overloaded methods return value? **Yes**, you have to.
 * Do you need to return a more general interface than the inferencer would find? **Yes**, otherwise you'd expose your implementation details for example.
 * Else... No, don't include a Type Annotation.
 * Related hint: Including Type Annotations speeds up compilation, also it's generally nice to see the return type of a method.


### PR DESCRIPTION
There are some additional cases where you need to have a Type Annotation, e.g. partially applied functions (`3 + (_: Double)`), but this might be out of scope and also, the compiler will tell you, if it's missing an annotation
