### PR TITLE
`new Service` trait will not compile instead `new Service {}`

### DIFF
--- a/sections/self_type.adoc
+++ b/sections/self_type.adoc
@@ -31,10 +31,10 @@ new Service with TestingModule
 If you were to try to instantiate it without mixing in the required trait it would fail like this:
 
 ```scala
-new Service
+new Service {}
 
 // class Service cannot be instantiated because it does not conform to its self-type Service with Module
-//              new Service
+//              new Service {}
 //              ^
 ```
 


### PR DESCRIPTION
`new Service` indeed did not compile but it was because was trying to instantiate a trait not because of the self type issue so did not compile in anyway.
