### PR TITLE
Update abstract_type_member.adoc

### DIFF
--- a/sections/abstract_type_member.adoc
+++ b/sections/abstract_type_member.adoc
@@ -56,6 +56,7 @@ trait OnlyNumbers {
 }
 
 val ints = new SimpleContainer with OnlyNumbers {
+  type A = Integer
   def value = 12
 }
 


### PR DESCRIPTION
Need to specify type upper bound to `Number`, `type A = Integer`
